### PR TITLE
fix: add fs.stat err guard

### DIFF
--- a/examples/grpc/package.json
+++ b/examples/grpc/package.json
@@ -8,8 +8,8 @@
     "build": "echo 'nothing to build'",
     "test": "echo 'nothing to test'",
     "lint": "echo 'nothing to lint'",
-    "server": "cross-env APPINSIGHTS_INSTRUMENTATIONKEY=ikey node ./server.js",
-    "client": "cross-env APPINSIGHTS_INSTRUMENTATIONKEY=ikey node ./client.js"
+    "server": "cross-env APPINSIGHTS_INSTRUMENTATIONKEY=3457abac-3812-4174-a542-e21d8d09c88f node ./server.js",
+    "client": "cross-env APPINSIGHTS_INSTRUMENTATIONKEY=3457abac-3812-4174-a542-e21d8d09c88f node ./client.js"
   },
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     "cross-env": "^7.0.2"
   },
   "dependencies": {
-    "@azure/monitor-opentelemetry-exporter": "^1.0.0-preview.1",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-preview.1",
     "@opentelemetry/api": "^0.8.2",
     "@opentelemetry/core": "^0.8.2",
     "@opentelemetry/node": "^0.8.2",

--- a/examples/grpc/package.json
+++ b/examples/grpc/package.json
@@ -8,8 +8,8 @@
     "build": "echo 'nothing to build'",
     "test": "echo 'nothing to test'",
     "lint": "echo 'nothing to lint'",
-    "server": "cross-env APPINSIGHTS_INSTRUMENTATIONKEY=3457abac-3812-4174-a542-e21d8d09c88f node ./server.js",
-    "client": "cross-env APPINSIGHTS_INSTRUMENTATIONKEY=3457abac-3812-4174-a542-e21d8d09c88f node ./client.js"
+    "server": "cross-env APPINSIGHTS_INSTRUMENTATIONKEY=ikey node ./server.js",
+    "client": "cross-env APPINSIGHTS_INSTRUMENTATIONKEY=ikey node ./client.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,25 +13,25 @@
     "publish": "lerna run publish"
   },
   "devDependencies": {
-    "@opentelemetry/api": "^0.8.2",
-    "@opentelemetry/tracing": "^0.8.2",
+    "@opentelemetry/api": "^0.8.3",
+    "@opentelemetry/tracing": "^0.8.3",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^14.0.5",
-    "@typescript-eslint/eslint-plugin": "^2.26.0",
-    "c8": "^7.1.0",
+    "@types/node": "^14.0.13",
+    "@typescript-eslint/eslint-plugin": "^2.34.0",
+    "c8": "^7.1.2",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-typescript": "^7.2.0",
     "eslint-config-prettier": "^6.10.1",
-    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-import": "^2.21.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.2",
-    "lerna": "^3.20.2",
-    "mocha": "^7.1.1",
+    "lerna": "^3.22.1",
+    "mocha": "^7.2.0",
     "nock": "^12.0.3",
     "prettier": "^2.0.2",
     "rimraf": "^3.0.2",
     "sinon": "^9.0.1",
     "ts-mocha": "^7.0.0",
-    "typescript": "^3.8.3"
+    "typescript": "^3.9.5"
   }
 }

--- a/packages/azure-opentelemetry-exporter/.eslintrc.js
+++ b/packages/azure-opentelemetry-exporter/.eslintrc.js
@@ -16,9 +16,11 @@ module.exports = {
     'no-underscore-dangle': [ 'error', { allowAfterThis: true }],
     'node/no-unsupported-features/es-syntax': ['error', { ignores: ['modules'] }],
     'import/prefer-default-export': 'off',
-    "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
-    "node/no-unpublished-import": ["error", {
-        "allowModules": ["@opentelemetry/api", "@opentelemetry/tracing"]
+    "import/no-extraneous-dependencies": ["error", {
+      "devDependencies": ["**/*.test.ts"]
+    }],
+    "node/no-extraneous-import": ["error", {
+      "allowModules": ["nock"]
     }],
   },
   parser: '@typescript-eslint/parser',

--- a/packages/azure-opentelemetry-exporter/.eslintrc.js
+++ b/packages/azure-opentelemetry-exporter/.eslintrc.js
@@ -1,13 +1,13 @@
 module.exports = {
   settings: {
     node: {
-      "resolvePaths": [__dirname],
-      "tryExtensions": [".ts"]
+      'resolvePaths': [__dirname],
+      'tryExtensions': ['.ts']
     }
   },
   extends: [
     'airbnb-typescript/base',
-    "plugin:node/recommended",
+    'plugin:node/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
     'plugin:prettier/recommended', // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
@@ -16,11 +16,11 @@ module.exports = {
     'no-underscore-dangle': [ 'error', { allowAfterThis: true }],
     'node/no-unsupported-features/es-syntax': ['error', { ignores: ['modules'] }],
     'import/prefer-default-export': 'off',
-    "import/no-extraneous-dependencies": ["error", {
-      "devDependencies": ["**/*.test.ts"]
+    'import/no-extraneous-dependencies': ['error', {
+      'devDependencies': ['**/*.test.ts']
     }],
-    "node/no-extraneous-import": ["error", {
-      "allowModules": ["nock"]
+    'node/no-extraneous-import': ['error', {
+      'allowModules': ['nock']
     }],
   },
   parser: '@typescript-eslint/parser',

--- a/packages/azure-opentelemetry-exporter/package.json
+++ b/packages/azure-opentelemetry-exporter/package.json
@@ -24,7 +24,8 @@
     "url": "https://github.com/microsoft/opentelemetry-azure-monitor-js"
   },
   "devDependencies": {
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "nock": "^12.0.3"
   },
   "dependencies": {
     "@opentelemetry/core": "^0.8.2",

--- a/packages/azure-opentelemetry-exporter/src/platform/nodejs/context/context.ts
+++ b/packages/azure-opentelemetry-exporter/src/platform/nodejs/context/context.ts
@@ -50,7 +50,7 @@ export class Context {
 
         this.tags[this.keys.applicationVersion] = Context.appVersion[packageJsonPath];
       } catch (exception) {
-        this._logger.warn('Failed to load Application version', exception);
+        this._logger.warn('Failed to load Application version');
       }
     }
   }
@@ -81,7 +81,7 @@ export class Context {
           Context.sdkVersion = packageJson.version;
         }
       } catch (exception) {
-        this._logger.warn('Failed to load Exporter version', exception);
+        this._logger.warn('Failed to load Exporter version');
       }
     }
 

--- a/packages/azure-opentelemetry-exporter/src/platform/nodejs/persist/fileSystemPersist.ts
+++ b/packages/azure-opentelemetry-exporter/src/platform/nodejs/persist/fileSystemPersist.ts
@@ -58,7 +58,9 @@ export class FileSystemPersist implements PersistentStorage {
     );
 
     fs.stat(tempDir, (statErr: Error | null, stats: fs.Stats) => {
-      if (stats.isDirectory()) {
+      if (statErr) {
+        callback(statErr);
+      } else if (stats.isDirectory()) {
         fs.readdir(tempDir, (error, origFiles) => {
           if (!error) {
             const files = origFiles.filter((f) =>

--- a/packages/azure-opentelemetry-exporter/test/export/export.test.ts
+++ b/packages/azure-opentelemetry-exporter/test/export/export.test.ts
@@ -1,14 +1,13 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable dot-notation */
 import * as assert from 'assert';
+import * as nock from 'nock';
 import { ExportResult } from '@opentelemetry/core';
 import { AzureMonitorBaseExporter } from '../../src/export/exporter';
 import { TelemetryProcessor } from '../../src/types';
 import { Envelope } from '../../src/Declarations/Contracts';
 import { DEFAULT_BREEZE_ENDPOINT } from '../../src/Declarations/Constants';
 import { failedBreezeResponse, partialBreezeResponse, successfulBreezeResponse } from '../breezeTestUtils';
-
-import nock = require('nock');
 
 function toObject(obj: object) {
   return JSON.parse(JSON.stringify(obj));

--- a/packages/azure-opentelemetry-exporter/test/platform/nodejs/httpSender.test.ts
+++ b/packages/azure-opentelemetry-exporter/test/platform/nodejs/httpSender.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
+import * as nock from 'nock';
 import { HttpSender } from '../../../src/platform/nodejs/httpSender';
 import { Envelope } from '../../../src/Declarations/Contracts';
 import { DEFAULT_BREEZE_ENDPOINT } from '../../../src/Declarations/Constants';
 import { successfulBreezeResponse, failedBreezeResponse, partialBreezeResponse } from '../../breezeTestUtils';
-
-import nock = require('nock');
 
 describe('HttpSender', () => {
   const scope = nock(DEFAULT_BREEZE_ENDPOINT).post('/v2/track');

--- a/packages/azure-opentelemetry-exporter/test/platform/nodejs/persist/fileSystemPersist.test.ts
+++ b/packages/azure-opentelemetry-exporter/test/platform/nodejs/persist/fileSystemPersist.test.ts
@@ -65,7 +65,9 @@ describe('FileSystemPersist', () => {
   afterEach((done) => {
     fs.readdir(tempDir, (err, files) => {
       if (err) {
-        done(err);
+        // eslint-disable-next-line no-console
+        console.error(err);
+        done();
       } else {
         assert.deepStrictEqual(files, []);
         done();
@@ -92,6 +94,15 @@ describe('FileSystemPersist', () => {
   });
 
   describe('#shift()', () => {
+    it('should not crash if file does not exist', (done) => {
+      const persister = new FileSystemPersist({ instrumentationKey });
+      assert.doesNotThrow(() => {
+        persister.shift((err) => {
+          assert.ok(err);
+          done();
+        });
+      });
+    });
     it('should get the first file on disk and return it', (done) => {
       const persister = new FileSystemPersist({ instrumentationKey });
 


### PR DESCRIPTION
- Adds error handler for where file is inaccessible due to file permissions or being deleted by another process. Some environments might also reset the tmp directory during restart.