### PR TITLE
fix: file persist not passing options

### DIFF
--- a/packages/azure-opentelemetry-exporter/src/export/exporter.ts
+++ b/packages/azure-opentelemetry-exporter/src/export/exporter.ts
@@ -52,7 +52,7 @@ export abstract class AzureMonitorBaseExporter implements BaseExporter {
 
     this._telemetryProcessors = [];
     this._sender = new HttpSender();
-    this._persister = new FileSystemPersist();
+    this._persister = new FileSystemPersist(this._options);
     this._retryTimer = null;
     this._logger.debug('AzureMonitorTraceExporter was successfully setup');
   }

--- a/packages/azure-opentelemetry-exporter/test/export/export.test.ts
+++ b/packages/azure-opentelemetry-exporter/test/export/export.test.ts
@@ -8,6 +8,7 @@ import { TelemetryProcessor } from '../../src/types';
 import { Envelope } from '../../src/Declarations/Contracts';
 import { DEFAULT_BREEZE_ENDPOINT } from '../../src/Declarations/Constants';
 import { failedBreezeResponse, partialBreezeResponse, successfulBreezeResponse } from '../breezeTestUtils';
+import { FileSystemPersist } from '../../src/platform';
 
 function toObject(obj: object) {
   return JSON.parse(JSON.stringify(obj));
@@ -25,6 +26,16 @@ describe('#AzureMonitorBaseExporter', () => {
       return this._telemetryProcessors;
     }
   }
+
+  it('should pass options to persister', () => {
+    const exporter = new TestExporter();
+    assert.ok(exporter['_options'].instrumentationKey);
+    assert.strictEqual(
+      (exporter['_persister'] as FileSystemPersist)['_options'].instrumentationKey,
+      exporter['_options'].instrumentationKey,
+    );
+    assert.deepStrictEqual((exporter['_persister'] as FileSystemPersist)['_options'], exporter['_options']);
+  });
 
   describe('Sender/Persister Controller', () => {
     describe('#exportEnvelopes()', () => {


### PR DESCRIPTION
Partially updates #45 
- Fix for `-undefined` folder suffix when trying to read file persisted telemetry

/cc @matt-paul